### PR TITLE
nginx: add default server on prometheus

### DIFF
--- a/ansible/environments/default_prometheus.yml
+++ b/ansible/environments/default_prometheus.yml
@@ -133,7 +133,7 @@ nginx_sites_default_https:
       }
 
   07-grafana-443:
-    - listen 443 ssl
+    - listen 443 ssl default_server
     - server_name {{grafana_domain_name}}
     - ssl_certificate  {{ certificats_dest }}/{{ grafana_certificat_name }}
     - ssl_certificate_key {{ certificats_dest }}/{{ grafana_certificat_key_name }}


### PR DESCRIPTION
When doing migration from an existing monitoring tool to another, it can
be useful to have a default domain on which we can fetch data without
domain. That allows tests easily, and avoid creating temporary domains
or switching too early into the new solution.