### PR TITLE
nginx: fix default server on prometheus

### DIFF
--- a/ansible/environments/default_prometheus.yml
+++ b/ansible/environments/default_prometheus.yml
@@ -133,7 +133,7 @@ nginx_sites_default_https:
       }
 
   07-grafana-443:
-    - listen 443 ssl default_server
+    - listen 443 ssl
     - server_name {{grafana_domain_name}}
     - ssl_certificate  {{ certificats_dest }}/{{ grafana_certificat_name }}
     - ssl_certificate_key {{ certificats_dest }}/{{ grafana_certificat_key_name }}
@@ -150,7 +150,7 @@ nginx_sites_default_https:
      - listen 80 default_server
      - return 301 https://$server_name$request_uri
   12-prometheus-443:
-     - listen 443 ssl
+     - listen 443 ssl default_server
      - server_name {{prometheus_domain_name}}
      - ssl_certificate  {{ certificats_dest }}/{{ prometheus_certificat_name }}
      - ssl_certificate_key {{ certificats_dest }}/{{ prometheus_certificat_key_name }}


### PR DESCRIPTION
The previous modification added it to grafana and not prometheus, which
as commented isn't that useful.