### PR TITLE
ansible: fix molecule setup to use systemd

### DIFF
--- a/ansible/molecule/default/Dockerfile.j2
+++ b/ansible/molecule/default/Dockerfile.j2
@@ -1,6 +1,6 @@
 FROM {{ item.image }}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo bash ca-certificates systemd && apt-get clean; \
     elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python python-devel python2-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \

--- a/ansible/molecule/default/molecule.yml
+++ b/ansible/molecule/default/molecule.yml
@@ -20,8 +20,7 @@ platforms:
       - "9093:9093"
       - "3000:3000"
     privileged: yes
-    # Adding some rm of systemctl because ansible try to use it by default in the container.
-    command: sh -c 'rm -f /bin/systemctl /sbin/initctl ; while sleep 3600; do :; done'
+    command: "/bin/systemd"
     groups:
      - tag_project_prometheus
      - tag_role_prometheus


### PR DESCRIPTION
Molecule test suite was blocked by the following error:

```
...
    TASK [geerlingguy.docker : Ensure Docker is started and enabled at boot.] ******
    fatal: [instance]: FAILED! => {"changed": false, "msg": "Could not find the requested service docker: "}
...
```