### PR TITLE
module-prometheus: add variable to disable eip

### DIFF
--- a/terraform/module-prometheus/prometheus.tf
+++ b/terraform/module-prometheus/prometheus.tf
@@ -106,6 +106,7 @@ resource "aws_instance" "prometheus" {
 resource "aws_eip" "prometheus" {
   instance = "${aws_instance.prometheus.id}"
   vpc      = true
+  count    = "${var.prometheus_enable_eip ? 1 : 0}"
 }
 
 ###

--- a/terraform/module-prometheus/variables.tf
+++ b/terraform/module-prometheus/variables.tf
@@ -80,6 +80,10 @@ variable "prometheus_ebs_optimized" {
   default = false
 }
 
+variable "prometheus_enable_eip" {
+  default = true
+}
+
 ###
 
 # grafana


### PR DESCRIPTION
In some case, we don't want to expose the prometheus instance directly.