### PR TITLE
terraform: add missing IAM permissions to make telegraf AWS checks working

### DIFF
--- a/terraform/module-prometheus/iam.tf
+++ b/terraform/module-prometheus/iam.tf
@@ -43,6 +43,16 @@ data "aws_iam_policy_document" "ec2-prometheus-checks" {
   statement {
     actions = [
       "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricData",
+      "ec2:DescribeInstanceStatus",
+      "elasticloadbalancing:DescribeLoadBalancers",
+      "elasticloadbalancing:DescribeListeners",
+      "acm:GetCertificate",
+      "rds:DescribeDBInstances",
+      "rds:DescribeEvents",
+      "ses:GetAccountSendingEnabled",
+      "ses:GetSendQuota",
+      "ses:GetSendStatistics",
     ]
 
     effect    = "Allow"


### PR DESCRIPTION
Needed for the [following scripts](https://github.com/cycloidio/ansible-telegraf/blob/master/tasks/aws_checks.yml#L25-L28) to work.